### PR TITLE
Calculate area of relevant topics inside selected schlag

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,8 @@
       "name": "bml-fast",
       "version": "0.0.0",
       "dependencies": {
-        "ol": "^9.1.0",
-        "ol-mapbox-style": "^12.3.1",
+        "ol": "^9.2.2",
+        "ol-mapbox-style": "^12.3.2",
         "roboto-fontface": "*",
         "vue": "^3.4.21",
         "vue-router": "^4.3.0",
@@ -3012,9 +3012,9 @@
       }
     },
     "node_modules/ol": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/ol/-/ol-9.1.0.tgz",
-      "integrity": "sha512-nDrkJ2tzZNpo/wzN/PpHV5zdxbnXZaFktoMaD2cFLEc6gCwlgLY21Yd8wnt/4FjaVYwLBnbN9USXSwIBGcyksQ==",
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/ol/-/ol-9.2.2.tgz",
+      "integrity": "sha512-YkuZW5MQTiKrr/0al1xuKarctNRvVj/anHZuq8rYMMq5BECG5E8rEOENOVFxhrbMX6T+un48D1Q0GtqBmU8Qdg==",
       "dependencies": {
         "color-rgba": "^3.0.0",
         "color-space": "^2.0.1",
@@ -3029,9 +3029,9 @@
       }
     },
     "node_modules/ol-mapbox-style": {
-      "version": "12.3.1",
-      "resolved": "https://registry.npmjs.org/ol-mapbox-style/-/ol-mapbox-style-12.3.1.tgz",
-      "integrity": "sha512-pKBpKBns4YUgeFCp+aeuJtM+D2BKLc1HJmk5tFL0Nv7u7nelZnInUs/+XnSlHOa1hPBSrOyL+7CvKtegEyuYlg==",
+      "version": "12.3.2",
+      "resolved": "https://registry.npmjs.org/ol-mapbox-style/-/ol-mapbox-style-12.3.2.tgz",
+      "integrity": "sha512-Qw9I6+WHz9zBsLNm8zWWb707Y/hXrQP1fcwK86pxcX/FklwyDxAhfJAdTkINHncZ331CBEWcqvi2tzoN23dgwg==",
       "dependencies": {
         "@mapbox/mapbox-gl-style-spec": "^13.23.1",
         "mapbox-to-css-font": "^2.4.1"

--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
     "test": "vue-tsc --pretty && eslint . --ext .vue,.js,.jsx,.cjs,.mjs --ignore-path .gitignore && prettier --check ./"
   },
   "dependencies": {
-    "ol": "^9.1.0",
-    "ol-mapbox-style": "^12.3.1",
+    "ol": "^9.2.2",
+    "ol-mapbox-style": "^12.3.2",
     "roboto-fontface": "*",
     "vue": "^3.4.21",
     "vue-router": "^4.3.0",

--- a/src/components/PlaceSearch.vue
+++ b/src/components/PlaceSearch.vue
@@ -42,7 +42,6 @@ const clear = () => {
 };
 
 const filter = (haystack, needle) => {
-  console.log(haystack, needle);
   const index = haystack.toLowerCase().indexOf(needle.toLowerCase());
   return index === -1 ? true : index;
 };

--- a/src/components/TheSchlagInfoPanel.vue
+++ b/src/components/TheSchlagInfoPanel.vue
@@ -80,11 +80,13 @@ import { equals } from 'ol/coordinate';
 import { useSchlag } from '../composables/useSchlag.js';
 import { mapReady, useMap } from '../composables/useMap.js';
 import { SCHLAEGE_SOURCE } from '../constants.js';
+import { useTopicIntersections } from '../composables/useTopicIntersections.js';
 
 const { schlagInfo } = useSchlag();
 const { map, mapView } = useMap();
 const route = useRoute();
 const router = useRouter();
+const { topicHectars } = useTopicIntersections();
 
 const emit = defineEmits(['schlag']);
 
@@ -131,6 +133,9 @@ watch(schlagInfo, (value) => {
     emit('schlag', true);
   }
 });
+
+// Area of relevant topics inside the current schlag
+watch(topicHectars, (value) => console.log(value));
 
 map.on('singleclick', (event) => {
   if (map.getView().getZoom() < 12) {

--- a/src/composables/useMap.js
+++ b/src/composables/useMap.js
@@ -4,14 +4,7 @@ import { Control, defaults } from 'ol/control.js';
 import ScaleLine from 'ol/control/ScaleLine.js';
 import Link from 'ol/interaction/Link.js';
 import { useGeographic } from 'ol/proj.js';
-import {
-  apply,
-  applyStyle,
-  getLayer,
-  getSource,
-  renderTransparent,
-  MapboxVectorLayer,
-} from 'ol-mapbox-style';
+import { apply, applyStyle, getLayer, getSource, renderTransparent } from 'ol-mapbox-style';
 import { getCenter } from 'ol/extent.js';
 import { shallowRef } from 'vue';
 import VectorTileLayer from 'ol/layer/VectorTile.js';
@@ -72,15 +65,6 @@ map.on('moveend', () => {
   };
 });
 
-map.addLayer(
-  new MapboxVectorLayer({
-    declutter: true,
-    visible: false,
-    minZoom: 14,
-    styleUrl: 'https://kataster.bev.gv.at/styles/kataster/style_basic.json',
-  }),
-);
-
 export const mapReady = apply(map, './map/style.json').then(() => {
   const { layers } = map.get('mapbox-style');
   layers.forEach((layer) => {
@@ -93,7 +77,7 @@ export const mapReady = apply(map, './map/style.json').then(() => {
 });
 
 /**
- * @type {Promise<import("ol/style/Style.js").StyleLike>}
+ * @type {Promise<import("ol/style/Style.js").StyleLike|import('ol/style/flat.js').FlatStyleLike>}
  */
 export const filterStyle = mapReady.then(async () => {
   const style = JSON.parse(JSON.stringify(map.get('mapbox-style')));

--- a/src/composables/useTopicIntersections.js
+++ b/src/composables/useTopicIntersections.js
@@ -1,0 +1,174 @@
+import { getSource } from 'ol-mapbox-style';
+import { shallowRef, watch } from 'vue';
+import { getPointResolution, transformExtent } from 'ol/proj';
+import { MVT } from 'ol/format';
+import { Map, View } from 'ol';
+import VectorTileLayer from 'ol/layer/VectorTile';
+import VectorTileSource from 'ol/source/VectorTile';
+import { Style, Fill } from 'ol/style';
+import { getBottomLeft, getCenter, getHeight, getTopRight, getWidth } from 'ol/extent';
+import { map, mapReady } from './useMap.js';
+import { topics } from './useTopics.js';
+import { schlagInfo } from './useSchlag.js';
+import { SCHLAEGE_SOURCE } from '../constants.js';
+
+/** @typedef {'nitrataktionsprogramm' | 'bdfl_l16_grundwasserschutz_acker' | 'bdfl_l26_wasserrahmenrichtlinie_ertragslagen-el_hoch_3' | 'bdfl_l26_wasserrahmenrichtlinie_ertragslagen-el_hoch_2' | 'bdfl_l26_wasserrahmenrichtlinie_ertragslagen-el_hoch_1' | 'bdfl_l26_wasserrahmenrichtlinie_ertragslagen-el_mittel' | 'bdfl_l26_wasserrahmenrichtlinie_ertragslagen-el_mittel_10' | 'bdfl_l26_wasserrahmenrichtlinie_ertragslagen-el_niedrig'} Topic */
+/** @typedef {(feature: import("ol/Feature.js").FeatureLike) => boolean} Filter */
+
+/** @type {{[Key in Topic]: Filter}} */
+const filtersByTopic = {
+  nitrataktionsprogramm: (feature) =>
+    feature.get('layer') === 'nitrataktionsprogramm' && feature.get('in_napv') === 1,
+  bdfl_l16_grundwasserschutz_acker: (feature) =>
+    feature.get('layer') === 'bdfl_l16_grundwasserschutz_acker',
+  'bdfl_l26_wasserrahmenrichtlinie_ertragslagen-el_hoch_3': (feature) =>
+    feature.get('layer') === 'bdfl_l26_wasserrahmenrichtlinie_ertragslagen' &&
+    feature.get('el') === 'EL hoch 3',
+  'bdfl_l26_wasserrahmenrichtlinie_ertragslagen-el_hoch_2': (feature) =>
+    feature.get('layer') === 'bdfl_l26_wasserrahmenrichtlinie_ertragslagen' &&
+    feature.get('el') === 'EL hoch 2',
+  'bdfl_l26_wasserrahmenrichtlinie_ertragslagen-el_hoch_1': (feature) =>
+    feature.get('layer') === 'bdfl_l26_wasserrahmenrichtlinie_ertragslagen' &&
+    feature.get('el') === 'EL hoch 1',
+  'bdfl_l26_wasserrahmenrichtlinie_ertragslagen-el_mittel': (feature) =>
+    feature.get('layer') === 'bdfl_l26_wasserrahmenrichtlinie_ertragslagen' &&
+    feature.get('el') === 'EL mittel',
+  'bdfl_l26_wasserrahmenrichtlinie_ertragslagen-el_mittel_10': (feature) =>
+    feature.get('layer') === 'bdfl_l26_wasserrahmenrichtlinie_ertragslagen' &&
+    feature.get('el') === 'EL mittel -10%',
+  'bdfl_l26_wasserrahmenrichtlinie_ertragslagen-el_niedrig': (feature) =>
+    feature.get('layer') === 'bdfl_l26_wasserrahmenrichtlinie_ertragslagen' &&
+    feature.get('el') === 'EL niedrig',
+};
+
+const topicKeys = Object.keys(filtersByTopic);
+
+const blackFill = new Style({
+  fill: new Fill({
+    color: 'black',
+  }),
+});
+
+const resolution = 5;
+const topicImageData = {};
+
+function createTopicLayer(topic) {
+  const topicLayer = new VectorTileLayer({
+    renderMode: 'vector',
+    style(feature) {
+      return filtersByTopic[topic](feature) ? blackFill : null;
+    },
+  });
+  topicLayer.on('postrender', (e) => {
+    const context = /** @type {CanvasRenderingContext2D} */ (e.context);
+    topicImageData[topic] = context.getImageData(
+      0,
+      0,
+      context.canvas.width,
+      context.canvas.height,
+    ).data;
+    context.clearRect(0, 0, context.canvas.width, context.canvas.height);
+  });
+  return topicLayer;
+}
+
+const topicHectarsAllZero = /** @type {{[Key in Topic]: number}} */ (
+  Object.freeze(topicKeys.reduce((acc, key) => ({ ...acc, [key]: 0 }), {}))
+);
+/** @type {import("vue").Ref<{[Key in Topic]: number}>} */
+const topicHectars = shallowRef(topicHectarsAllZero);
+
+function updateTopicHectars() {
+  schlagLayer.changed();
+  topicHectars.value = topicHectarsAllZero;
+  if (!schlagInfo.value || schlagInfo.value.loading) {
+    return;
+  }
+
+  const extent = transformExtent(schlagInfo.value.extent, 'EPSG:4326', 'EPSG:3857');
+  const bl = getBottomLeft(extent).map((x) => Math.floor(x / resolution) * resolution);
+  const tr = getTopRight(extent).map((y) => Math.ceil(y / resolution) * resolution);
+  const adjustedExtent = [...bl, ...tr];
+  offscreenMap.setSize([
+    Math.ceil(getWidth(adjustedExtent) / resolution),
+    Math.ceil(getHeight(adjustedExtent) / resolution),
+  ]);
+  offscreenMap.once('rendercomplete', () => {
+    const pixelResolution =
+      resolution * getPointResolution('EPSG:3857', 1, getCenter(adjustedExtent));
+    let schlagArea = 0;
+    const topicArea = /** @type {{[Key in Topic]: number}} */ ({});
+    for (let i = 0, ii = schlagImageData.length; i < ii; i += 4) {
+      const schlagAlpha = schlagImageData[i + 3];
+      if (schlagAlpha > 0) {
+        schlagArea += pixelResolution * pixelResolution * (schlagAlpha / 255);
+        for (let t = 0, tt = topicKeys.length; t < tt; ++t) {
+          const topic = topicKeys[t];
+          const topicAlpha = topicImageData[topic][i + 3];
+          if (topicAlpha > 0) {
+            topicArea[topic] =
+              (topicArea[topic] || 0) +
+              pixelResolution * pixelResolution * (Math.min(schlagAlpha, topicAlpha) / 255);
+          }
+        }
+      }
+    }
+    const calibrationFactor = (schlagInfo.value.sl_flaeche_brutto_ha * 10000) / schlagArea;
+    topicKeys.forEach((topic) => {
+      topicArea[topic] = ((topicArea[topic] || 0) * calibrationFactor) / 10000;
+    });
+    topicHectars.value = topicArea;
+  });
+  offscreenMap.getView().fit(transformExtent(adjustedExtent, 'EPSG:3857', 'EPSG:4326'));
+}
+
+watch([schlagInfo, topics], updateTopicHectars);
+
+const schlagLayer = new VectorTileLayer({
+  renderMode: 'vector',
+  style(feature) {
+    return feature.get('layer') === SCHLAEGE_SOURCE && feature.getId() === schlagInfo.value?.id
+      ? blackFill
+      : null;
+  },
+});
+let schlagImageData;
+schlagLayer.on('postrender', (e) => {
+  const context = /** @type {CanvasRenderingContext2D} */ (e.context);
+  schlagImageData = context.getImageData(0, 0, context.canvas.width, context.canvas.height).data;
+});
+
+const topicLayers = topicKeys.map(createTopicLayer);
+
+const offscreenMap = new Map({
+  pixelRatio: 1,
+  controls: [],
+  interactions: [],
+  target: document.createElement('div'),
+  layers: [...topicLayers, schlagLayer],
+  view: new View({
+    resolutions: [resolution],
+  }),
+});
+
+mapReady.then(() => {
+  const templateSource = /** @type {import("ol/source/VectorTile.js").default} */ (
+    getSource(map, 'agrargis')
+  );
+  const source = new VectorTileSource({
+    format: new MVT(),
+    minZoom: 15,
+    maxZoom: 15,
+    tileUrlFunction: templateSource.getTileUrlFunction(),
+  });
+  offscreenMap
+    .getLayers()
+    .forEach((layer) => layer instanceof VectorTileLayer && layer.setSource(source));
+});
+
+/**
+ * @returns {{topicHectars: import("vue").Ref<{[Key in Topic]: number}>}}
+ */
+export function useTopicIntersections() {
+  return { topicHectars };
+}

--- a/src/composables/useTopics.js
+++ b/src/composables/useTopics.js
@@ -1,0 +1,59 @@
+import { reactive } from 'vue';
+import { map, mapReady } from './useMap.js';
+
+/**
+ * @typedef Topic
+ * @property {string} id
+ * @property {string} label
+ * @property {string|undefined} warning
+ * @property {string} color
+ * @property {boolean} inExtent
+ * @property {boolean} inSchlagExtent
+ * @property {number} urlSort
+ * @property {number} displaySort
+ * @property {boolean} visible
+ * @property {string|undefined} category
+ */
+
+/** @type {Array<Topic>} */
+export const topics = reactive([]);
+
+mapReady.then(() => {
+  const { layers } = map.get('mapbox-style');
+  topics.push(
+    ...Object.values(
+      layers
+        .filter((l) => l.metadata?.group === 'one' && l.type !== 'raster')
+        .map((l) => ({
+          id: l.id,
+          label: l.metadata?.label,
+          warning: l.metadata?.warning,
+          color: l.paint?.['fill-color'],
+          urlSort: l.metadata?.urlSort,
+          displaySort: l.metadata?.displaySort || Number.MAX_SAFE_INTEGER,
+          category: l.metadata?.category,
+        }))
+        .reduce((acc, { id, label, warning, color, urlSort, displaySort, category }) => {
+          if (!(label in acc)) {
+            acc[label] = {
+              id,
+              label,
+              warning,
+              color,
+              inExtent: false,
+              inSchlagExtent: false,
+              urlSort,
+              displaySort,
+              category,
+              visible: false,
+            };
+          }
+          return acc;
+        }, {}),
+    ),
+  );
+});
+
+export function useTopics() {
+  return { topics };
+}


### PR DESCRIPTION
Dieser Pull Request fügt ein `useTopicIntersections()` Composable hinzu, welches für die relevanten Agraratlas-Daten die Flächenanteile im selektierten Schlag berechnet.