### PR TITLE
Only show schlag selection cursor when selection is possible

### DIFF
--- a/src/composables/useSchlag.js
+++ b/src/composables/useSchlag.js
@@ -132,7 +132,7 @@ map.on('click', (event) => {
   }
 });
 map.on('pointermove', (event) => {
-  if (event.dragging) {
+  if (!allData.value.datawindow || event.dragging) {
     return;
   }
   map.getTargetElement().style.cursor = getSchlagAtPixel(event.pixel) ? 'pointer' : '';


### PR DESCRIPTION
Damit der Auswahl-Cursor für Schläge in der Karte auch nur erscheint, wenn ein Schlag ausgewählt werden kann.