### PR TITLE
Use utf-8 for save and load

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "dependencies": {
         "@w3geo/vue-place-search": "^1.0.2",
         "csvtojson": "^2.0.10",
-        "downloadjs": "^1.4.7",
         "ol": "^10.1.1-dev.1726748362724",
         "ol-mapbox-style": "^12.3.5",
         "pmtiles": "^3.1.0",
@@ -1579,11 +1578,6 @@
       "engines": {
         "node": ">=6.0.0"
       }
-    },
-    "node_modules/downloadjs": {
-      "version": "1.4.7",
-      "resolved": "https://registry.npmjs.org/downloadjs/-/downloadjs-1.4.7.tgz",
-      "integrity": "sha512-LN1gO7+u9xjU5oEScGFKvXhYf7Y/empUIIEAGBs1LzUq/rg5duiDrkuH5A2lQGd5jfMOb9X9usDa2oVXwJ0U/Q=="
     },
     "node_modules/earcut": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
   "dependencies": {
     "@w3geo/vue-place-search": "^1.0.2",
     "csvtojson": "^2.0.10",
-    "downloadjs": "^1.4.7",
     "ol": "^10.1.1-dev.1726748362724",
     "ol-mapbox-style": "^12.3.5",
     "pmtiles": "^3.1.0",

--- a/src/components/TheLoadSavePanel.vue
+++ b/src/components/TheLoadSavePanel.vue
@@ -43,7 +43,6 @@
 </template>
 
 <script setup>
-import download from 'downloadjs';
 import { dataWindow, useDataEntries } from '../composables/useDataEntries.js';
 import { ref } from 'vue';
 
@@ -51,20 +50,24 @@ const { savedData } = useDataEntries();
 const inputFile = ref(null);
 const showAlert = ref({ color: 'green', text: '', show: false });
 
+const link = document.createElement('a');
+
 function downloadJson() {
   const data = JSON.stringify(savedData.value);
   const today = new Date();
   const filename = `fast-export-${today.getFullYear()}-${(today.getMonth() + 1).toString().padStart(2, '0')}-${today.getDate().toString().padStart(2, '0')}.txt`;
-  download(data, filename, 'text/plain');
+  link.href = 'data:text/plain;charset=utf-8,' + encodeURIComponent(data);
+  link.download = filename;
+  link.click();
 }
 
 function readJson() {
   const reader = new FileReader();
   if (inputFile.value) {
-    reader.readAsText(inputFile.value, 'Windows-1252');
+    reader.readAsText(inputFile.value, 'utf-8');
     reader.onload = () => {
       try {
-        const imported = JSON.parse(reader.result.toString());
+        const imported = JSON.parse(/** @type {string} */ (reader.result));
         savedData.value = imported;
         localStorage.setItem('fasttool', JSON.stringify(savedData.value));
         showAlert.value.text = 'Import erfolgreich. Die Daten wurden eingelesen.';


### PR DESCRIPTION
#78 macht bei mir leider Sonderzeichen beim Speichern/Laden kaputt.

Die Änderungen in diesem Pull Request sollten einen korrekten utf-8 Export und Import auf allen Plattformen sicherstellen (Code ist aus anderen Projekten von uns übernommen). Bei mir funktioniert es (am Mac), bitte auf Windows testen vor dem Mergen, @arnold-pichler.