### PR TITLE
Use full resolution for schlag geometry

### DIFF
--- a/src/composables/useSchlag.js
+++ b/src/composables/useSchlag.js
@@ -49,7 +49,7 @@ async function getSchlagParts(feature) {
   const extent = feature.getGeometry().getExtent();
   const source = /** @type {import("ol/source.js").VectorTile} */ (getSource(map, 'agrargis'));
   const tilePromises = [];
-  source.getTileGrid().forEachTileCoord(extent, 12, (tileCoord) => {
+  source.getTileGrid().forEachTileCoord(extent, 15, (tileCoord) => {
     tilePromises.push(
       new Promise((resolve, reject) => {
         const [z, x, y] = tileCoord;


### PR DESCRIPTION
Damit werden die Schlag-Geometrien in der höchsten verfügbaren Auflösung gespeichert (Zoom 15) statt in einer reduzierten (Zoom 12).