### PR TITLE
Get schlag data from zoom level 15 tiles

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "csvtojson": "^2.0.10",
         "ol": "^10.1.1-dev.1726748362724",
         "ol-mapbox-style": "^12.3.5",
-        "pmtiles": "^3.1.0",
         "roboto-fontface": "*",
         "vue": "^3.4.21",
         "vue-router": "^4.3.0",
@@ -802,22 +801,14 @@
       "version": "7946.0.14",
       "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.14.tgz",
       "integrity": "sha512-WCfD5Ht3ZesJUsONdhvm84dmzWOiOzOAqOncN0++w0lBw1o8OuDNJF2McvvCef/yBqb/HYRahp1BYtODFQ8bRg==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/json5": {
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true
-    },
-    "node_modules/@types/leaflet": {
-      "version": "1.9.12",
-      "resolved": "https://registry.npmjs.org/@types/leaflet/-/leaflet-1.9.12.tgz",
-      "integrity": "sha512-BK7XS+NyRI291HIo0HCfE18Lp8oA30H1gpi1tf0mF3TgiCEzanQjOqNZ4x126SXzzi2oNSZhZ5axJp1k0iM6jg==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/geojson": "*"
-      }
     },
     "node_modules/@types/node": {
       "version": "20.12.7",
@@ -2130,12 +2121,6 @@
         "reusify": "^1.0.4"
       }
     },
-    "node_modules/fflate": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
-      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
-      "license": "MIT"
-    },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -3242,16 +3227,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
       "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
-    },
-    "node_modules/pmtiles": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/pmtiles/-/pmtiles-3.1.0.tgz",
-      "integrity": "sha512-6JvgAQ8gElP1Ilg6ILM4KqleeKS+QcwpW8PXqhPWjRFmqF42yyUJ8sP3dZHQXm+G0HYXuw1kGlMTdVEs583pCQ==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@types/leaflet": "^1.9.8",
-        "fflate": "^0.8.0"
-      }
     },
     "node_modules/possible-typed-array-names": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "csvtojson": "^2.0.10",
     "ol": "^10.1.1-dev.1726748362724",
     "ol-mapbox-style": "^12.3.5",
-    "pmtiles": "^3.1.0",
     "roboto-fontface": "*",
     "vue": "^3.4.21",
     "vue-router": "^4.3.0",

--- a/src/composables/useMap.js
+++ b/src/composables/useMap.js
@@ -8,7 +8,6 @@ import { apply, getSource, renderTransparent } from 'ol-mapbox-style';
 import { getCenter } from 'ol/extent.js';
 import { shallowRef } from 'vue';
 import { AGRARATLAS_STYLE_URL, INITIAL_EXTENT } from '../constants.js';
-import { PMTiles } from 'pmtiles';
 
 /**
  * @typedef {Object} MapView
@@ -65,41 +64,7 @@ map.on('moveend', () => {
   };
 });
 
-const pmtilesByUrl = {};
-const tileUrlRegex = /^pmtiles:\/\/(.+)\/([0-9]+)\/([0-9]+)\/([0-9]+).mvt$/;
-const tileCoordRegex = /\/([0-9]+)\/([0-9]+)\/([0-9]+).mvt$/;
-export const transformRequest = async (url, type) => {
-  /** @type {PMTiles} */
-  let pmtiles;
-  if (url.startsWith('pmtiles://')) {
-    const baseUrl = url.slice(10).replace(tileCoordRegex, '');
-    if (!pmtilesByUrl[baseUrl]) {
-      const agraratlasStyleUrl = new URL(AGRARATLAS_STYLE_URL, window.location.href);
-      pmtilesByUrl[baseUrl] = new PMTiles(new URL(url.slice(10), agraratlasStyleUrl).href);
-    }
-    pmtiles = pmtilesByUrl[baseUrl];
-  }
-  if (!pmtiles) {
-    return url;
-  }
-  if (type === 'Source') {
-    const tileJson = await pmtiles.getTileJson(url);
-    return `data:application/json,${encodeURIComponent(JSON.stringify(tileJson))}`;
-  }
-  if (type === 'Tiles') {
-    const [, baseUrl, z, x, y] = url.match(tileUrlRegex);
-    const tileResult = await pmtilesByUrl[baseUrl].getZxy(Number(z), Number(x), Number(y));
-    const data = tileResult?.data ?? new ArrayBuffer(0);
-    const objectUrl = URL.createObjectURL(new Blob([data]));
-    window.setTimeout(() => URL.revokeObjectURL(objectUrl), 10000);
-    return objectUrl;
-  }
-  return url;
-};
-
-export const mapReady = apply(map, AGRARATLAS_STYLE_URL, {
-  transformRequest,
-}).then(() => {
+export const mapReady = apply(map, AGRARATLAS_STYLE_URL).then(() => {
   const { layers } = map.get('mapbox-style');
   layers.forEach((layer) => {
     const source = getSource(map, layer.source);

--- a/src/composables/useSchlag.js
+++ b/src/composables/useSchlag.js
@@ -121,7 +121,7 @@ async function setSchlagInfo(feature) {
     )
   );
   schlagInfo.value = {
-    ...feature.getProperties(),
+    ...features[0].getProperties(),
     loading: false,
     id: feature.getId(),
     extent: transformExtent(extent, 'EPSG:3857', 'EPSG:4326'),


### PR DESCRIPTION
Die Vektorkacheln des Agraratlas beinhalten die inspire id nur noch auf Zoom 15.