### PR TITLE
Finaltesting bugfixes 1

### DIFF
--- a/src/components/TheEntryForm.vue
+++ b/src/components/TheEntryForm.vue
@@ -966,7 +966,6 @@ function cultureChanged(index) {
     entry.value.cultures[index].kultur = '';
     entry.value.cultures[index].nminvorgabe = 0;
     entry.value.cultures[index].nmin = 0;
-    return;
   }
 
   nMinCalculator(index);

--- a/src/components/TheEntryForm.vue
+++ b/src/components/TheEntryForm.vue
@@ -897,6 +897,11 @@ function nMinCalculator(index) {
     return;
   }
 
+  const vorkulturgemüse =
+    index > 1
+      ? tableAttribut('kulturen', entry.value.cultures[index - 1].kultur, 'Gemüsekultur') === 'x'
+      : false;
+
   const isgemüse =
     tableAttribut('kulturen', entry.value.cultures[index].kultur, 'Gemüsekultur') === 'x';
   const vfgemüse = tableAttribut('kulturen', entry.value.vorfrucht, 'Gemüsekultur') === 'x';
@@ -939,7 +944,7 @@ function nMinCalculator(index) {
         entry.value.cultures[index].nmin = entry.value.cultures[index].nminvorgabe;
       }
     }
-    if (index > 1 && entry.value.cultures[index - 1].kultur !== '') {
+    if (index > 1 && vorkulturgemüse && entry.value.cultures[index - 1].kultur !== '') {
       entry.value.cultures[index].nminvorgabe = tableAttribut(
         'kulturen',
         entry.value.cultures[index - 1].kultur,

--- a/src/components/TheEntryForm.vue
+++ b/src/components/TheEntryForm.vue
@@ -859,7 +859,7 @@ function npkLabel(what, type, fid) {
 }
 
 function addFertilization(cindex) {
-  entry.value.cultures[cindex].duengung.push({ ...emptyFertilization });
+  entry.value.cultures[cindex].duengung.push(JSON.parse(JSON.stringify(emptyFertilization)));
 }
 
 function deleteFertilization(cindex, findex) {
@@ -1013,7 +1013,7 @@ function deleteCulture(nr) {
 }
 
 function addCulture() {
-  entry.value.cultures.push({ ...emptyCulture });
+  entry.value.cultures.push(JSON.parse(JSON.stringify(emptyCulture)));
 }
 
 function dataSort(a, b) {
@@ -1034,9 +1034,9 @@ async function saveData(copy) {
   }
 
   if (!copy && currentSaved.value !== null) {
-    savedData.value[currentSaved.value] = { ...entry.value };
+    savedData.value[currentSaved.value] = JSON.parse(JSON.stringify(entry.value));
   } else {
-    savedData.value.push({ ...entry.value });
+    savedData.value.push(JSON.parse(JSON.stringify(entry.value)));
     savedData.value.sort(dataSort);
   }
   localStorage.setItem('fasttool', JSON.stringify(savedData.value));

--- a/src/components/TheFertilizerBalance.vue
+++ b/src/components/TheFertilizerBalance.vue
@@ -83,6 +83,9 @@
                       !outputConfig[pkey].print ||
                       (pkey === 'nminman' &&
                         Number(pvalue) === Number(entry.cultures[index].nminvorgabe)) ||
+                      (pkey === 'nminman' &&
+                        Number(pvalue) === 0 &&
+                        Number(entry.cultures[index].nmin) !== 0) ||
                       (outputConfig[pkey].printnotzero && Number(pvalue) == 0),
                     bold: outputConfig[pkey].bold,
                   }"

--- a/src/composables/useBalanceCalculator.js
+++ b/src/composables/useBalanceCalculator.js
@@ -881,17 +881,15 @@ function calculateBilanz(retVal) {
         if (retVal[c - 1].nbilanz > 20) {
           if (hf1gemüse && hf2gemüse) {
             if (
-              (hf2manuell && retVal[c - 1].nbilanz * redfaktor > hf2manuellnmin) ||
-              (!hf2manuell && retVal[c - 1].nbilanz * redfaktor > hf1nmin)
+              (hf2manuell && retVal[c - 1].nsaldoff >= hf2manuellnmin) ||
+              (!hf2manuell && retVal[c - 1].nsaldoff >= hf1nmin)
             ) {
-              const maxBilanz = Math.min(retVal[c - 1].nbilanz, 100);
-              retVal[c].nsaldo = maxBilanz * redfaktor;
+              retVal[c].nsaldo = retVal[c - 1].nsaldoff;
               retVal[c].vfwert = 0;
             }
           } else {
             if (retVal[c - 1].nbilanz > 20) {
-              const maxBilanz = Math.min(retVal[c - 1].nbilanz, 100);
-              retVal[c].nsaldo = maxBilanz * redfaktor;
+              retVal[c].nsaldo = retVal[c - 1].nsaldoff;
             }
           }
         }
@@ -905,7 +903,7 @@ function calculateBilanz(retVal) {
           entry.value.teilnahme_grundwasserschutz_acker &&
           hf1gemüse &&
           hf2gemüse &&
-          retVal[c - 1].nbilanz * redfaktor > hf2manuellnmin
+          retVal[c - 1].nsaldoff >= hf2manuellnmin
         ) {
           retVal[c].nminman = 0;
         }

--- a/src/composables/useBalanceCalculator.js
+++ b/src/composables/useBalanceCalculator.js
@@ -993,12 +993,14 @@ function calculateBilanz(retVal) {
       retVal[c].nsaldoff = maxBilanz * redfaktor;
     }
 
-    retVal[c].duengeobergrenzered =
+    retVal[c].duengeobergrenzered = Math.max(
+      0,
       retVal[c].duengeobergrenze -
-      retVal[c].nsaldo -
-      retVal[c].vfwert -
-      retVal[c].vfwertzf -
-      retVal[c].nminman;
+        retVal[c].nsaldo -
+        retVal[c].vfwert -
+        retVal[c].vfwertzf -
+        retVal[c].nminman,
+    );
 
     summen.dogRedSumme += retVal[c].duengeobergrenzered;
 

--- a/src/composables/useBalanceCalculator.js
+++ b/src/composables/useBalanceCalculator.js
@@ -770,7 +770,12 @@ function calculateBilanz(retVal) {
         (vfgemüse && !hfgemüse && !zfgenutzt && !hfmanuell) ||
         (!vfgemüse && !zfgenutzt)
       ) {
-        if (entry.value.flaeche_grundwasserschutz > 0 && hfgemüse && retVal[c].nsaldo <= vfnmin) {
+        if (
+          entry.value.flaeche_grundwasserschutz > 0 &&
+          vfgemüse &&
+          hfgemüse &&
+          retVal[c].nsaldo <= vfnmin
+        ) {
           retVal[c].vfwert = vfnmin;
           retVal[c].nminman = 0;
           retVal[c].nsaldo = 0;

--- a/src/composables/useDataEntries.js
+++ b/src/composables/useDataEntries.js
@@ -89,11 +89,11 @@ export const emptyEntry = {
   extent: [],
   parts: [],
   schlaginfo: { basic: null, programs: null },
-  cultures: [{ ...emptyCulture }, { ...emptyCulture }],
+  cultures: [JSON.parse(JSON.stringify(emptyCulture)), JSON.parse(JSON.stringify(emptyCulture))],
 };
 
 /** @type {import('vue').Ref<DataEntry>} */
-export const entry = ref({ ...emptyEntry });
+export const entry = ref(JSON.parse(JSON.stringify(emptyEntry)));
 
 /** @type {import('vue').Ref<Array>} */
 export const savedData = ref([]);


### PR DESCRIPTION
Dieser PR korrigiert div. Fehler aus der aktuellen Feedback-Runde:

- Fehler beim Anlegen leerer Objekte, führt zu "Geisterdüngungen" - Fix ( #159 )
- Max. N-Düngungg nicht negativ (als min. 0) ( #153 , #162 )
- Fehler beim Löschen einer Zwischenfrucht gefixed ( #160 )
- Fehler beim Berechnen des Falls VF (nichtGem) -> HF (Gem) mit N-Saldo und NMIN ( #161)
- Die Unter- / Obergrenzen für den Vergleich NSaldo / Nmin wurden korrigiert ( #163 ) - HINWEIS: Es gibt noch ein Problem mit dem Anzeigen von NMin Manuell, wenn 0, da muss ich noch nachschärfen.
- Aus Nicht-Gemüse Vorkulturen wird kein NMin-Default mehr definiert ( #164 )
